### PR TITLE
feat: Add FTP port configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "^5.1.3"
       },
       "engines": {
-        "vscode": "^1.80.0"
+        "vscode": "^1.96.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
           "default": "",
           "description": "FTP 호스트 주소"
         },
+        "ftpMini.port": {
+          "type": "string",
+          "default": "21",
+          "description": "FTP 포트 번호 (기본값: 21)"
+        },
         "ftpMini.username": {
           "type": "string",
           "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('ftpMini');
     Promise.all([
         config.update('host', undefined, true),
+        config.update('port', undefined, true),
         config.update('username', undefined, true),
         config.update('password', undefined, true),
         config.update('remoteRoot', undefined, true),


### PR DESCRIPTION
- Add port configuration to package.json
- Implement port validation and input handling
- Add default port (21) support
- Improve port input UI with validation
- Add port information to connection logs
- Handle empty port input with default value
- Add port initialization and cleanup

This change allows users to specify custom FTP ports while maintaining default port (21) as fallback. Port validation ensures only valid port numbers (1-65535) are accepted.