### PR TITLE
feat: Add SFTP Support to FTP Mini Extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "^5.1.3"
       },
       "engines": {
-        "vscode": "^1.80.0"
+        "vscode": "^1.96.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "basic-ftp": "^5.0.5"
+        "basic-ftp": "^5.0.5",
+        "ssh2": "^1.15.0"
       },
       "devDependencies": {
         "@types/node": "^16.18.34",
+        "@types/ssh2": "^1.15.5",
         "@types/vscode": "^1.96.0",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "@typescript-eslint/parser": "^5.59.8",
@@ -607,6 +609,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.96.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
@@ -933,6 +955,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -968,6 +999,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/bl": {
@@ -1033,6 +1073,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/callsites": {
@@ -1137,6 +1186,20 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2041,6 +2104,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2489,6 +2559,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -2540,6 +2616,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.20.0"
       }
     },
     "node_modules/stdin-discarder": {
@@ -2640,6 +2733,12 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2679,6 +2778,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
           "default": "",
           "description": "FTP 호스트 주소"
         },
+        "ftpMini.port": {
+          "type": "string",
+          "default": "21",
+          "description": "FTP 포트 번호 (기본값: 21)"
+        },
         "ftpMini.username": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,15 @@
     "configuration": {
       "title": "FTP Mini",
       "properties": {
+        "ftpMini.protocol": {
+          "type": "string",
+          "enum": [
+            "ftp",
+            "sftp"
+          ],
+          "default": "ftp",
+          "description": "연결 프로토콜 (FTP 또는 SFTP)"
+        },
         "ftpMini.host": {
           "type": "string",
           "default": "",
@@ -76,6 +85,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.18.34",
+    "@types/ssh2": "^1.15.5",
     "@types/vscode": "^1.96.0",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
@@ -85,7 +95,8 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "basic-ftp": "^5.0.5"
+    "basic-ftp": "^5.0.5",
+    "ssh2": "^1.15.0"
   },
   "publisher": "faith6",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('ftpMini');
     Promise.all([
         config.update('host', undefined, true),
+        config.update('port', undefined, true),
         config.update('username', undefined, true),
         config.update('password', undefined, true),
         config.update('remoteRoot', undefined, true),

--- a/src/sftpManager.ts
+++ b/src/sftpManager.ts
@@ -1,0 +1,237 @@
+import * as vscode from 'vscode';
+import { Client, SFTPWrapper, Stats } from 'ssh2';
+import { Logger } from './logger';
+import * as path from 'path';
+import * as fs from 'fs';
+
+interface SFTPDirectoryEntry {
+    filename: string;
+    longname: string;
+    attrs: Stats;
+}
+
+export class SFTPManager {
+    private client: Client | null = null;
+    private sftp: SFTPWrapper | null = null;
+    private isConnected: boolean = false;
+    private readonly MAX_RETRY_ATTEMPTS = 3;
+    private readonly RETRY_DELAY = 1000;
+
+    async connect(host: string, port: string, username: string, password: string, remoteRoot: string): Promise<boolean> {
+        try {
+            if (this.isConnected && this.client && this.sftp) {
+                return true;
+            }
+
+            if (this.client) {
+                this.client.end();
+                this.client = null;
+                this.sftp = null;
+            }
+
+            Logger.log(`SFTP 서버에 연결 시도 중... (${host}:${port})`);
+
+            return new Promise((resolve, reject) => {
+                this.client = new Client();
+
+                this.client.on('ready', async () => {
+                    try {
+                        this.client?.sftp((err: Error | null | undefined, sftp: SFTPWrapper) => {
+                            if (err) {
+                                reject(err);
+                                return;
+                            }
+                            this.sftp = sftp;
+                            this.isConnected = true;
+                            Logger.log(`SFTP 서버에 성공적으로 연결되었습니다. (작업 디렉토리: ${remoteRoot})`);
+                            resolve(true);
+                        });
+                    } catch (error) {
+                        reject(error);
+                    }
+                });
+
+                this.client.on('error', (err: Error) => {
+                    reject(err);
+                });
+
+                this.client.connect({
+                    host,
+                    port: parseInt(port),
+                    username,
+                    password
+                });
+            });
+        } catch (error) {
+            this.isConnected = false;
+            if (this.client) {
+                this.client.end();
+                this.client = null;
+                this.sftp = null;
+            }
+            
+            const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다';
+            Logger.log(`SFTP 연결 실패: ${errorMessage}`);
+            throw new Error(`SFTP 연결 실패: ${errorMessage}`);
+        }
+    }
+
+    async uploadFile(localPath: string, remotePath: string): Promise<void> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.fastPut(localPath, remotePath, (err: Error | null | undefined) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve();
+            });
+        });
+    }
+
+    async downloadFile(remotePath: string, localPath: string): Promise<void> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.fastGet(remotePath, localPath, (err: Error | null | undefined) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve();
+            });
+        });
+    }
+
+    async deleteFile(remotePath: string): Promise<void> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.unlink(remotePath, (err: Error | null | undefined) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve();
+            });
+        });
+    }
+
+    async createDirectory(remotePath: string): Promise<void> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.mkdir(remotePath, (err: Error | null | undefined) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve();
+            });
+        });
+    }
+
+    async listDirectory(remotePath: string): Promise<{ files: string[], directories: string[] }> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.readdir(remotePath, (err: Error | null | undefined, list: SFTPDirectoryEntry[]) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                const files: string[] = [];
+                const directories: string[] = [];
+
+                for (const item of list) {
+                    const itemPath = path.posix.join(remotePath, item.filename).replace(/\\/g, '/');
+                    if (item.attrs.isDirectory()) {
+                        directories.push(itemPath);
+                    } else {
+                        files.push(itemPath);
+                    }
+                }
+
+                resolve({ files, directories });
+            });
+        });
+    }
+
+    async moveFile(oldPath: string, newPath: string): Promise<void> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.rename(oldPath, newPath, (err: Error | null | undefined) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve();
+            });
+        });
+    }
+
+    async getFileSize(remotePath: string): Promise<number> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        return new Promise((resolve, reject) => {
+            this.sftp?.stat(remotePath, (err: Error | null | undefined, stats: Stats) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve(stats.size);
+            });
+        });
+    }
+
+    async ensureDirectory(remotePath: string): Promise<void> {
+        if (!this.isConnected || !this.sftp) {
+            throw new Error('SFTP 연결이 되어있지 않습니다.');
+        }
+
+        const parts = remotePath.split('/').filter(Boolean);
+        let currentPath = '';
+
+        for (const part of parts) {
+            currentPath += '/' + part;
+            try {
+                await this.createDirectory(currentPath);
+            } catch (error) {
+                // 디렉토리가 이미 존재하는 경우 무시
+                if (!(error instanceof Error && error.message.includes('already exists'))) {
+                    throw error;
+                }
+            }
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.client) {
+            this.client.end();
+            this.client = null;
+            this.sftp = null;
+            this.isConnected = false;
+        }
+    }
+
+    isActive(): boolean {
+        return this.isConnected;
+    }
+} 


### PR DESCRIPTION
## Description
This PR implements SFTP support as requested in #3, allowing users to choose between FTP and SFTP protocols while maintaining all existing functionality.

## Changes
- Added SFTPManager class for SFTP operations
- Integrated SFTP support into FTPManager
- Added protocol selection in setup wizard
- Implemented proper path handling for cross-platform compatibility
- Added comprehensive error handling
- Fixed path synchronization issues

## Testing
- Tested SFTP connection and authentication
- Verified file operations (upload/download)
- Confirmed directory synchronization
- Tested error handling and reconnection

## Breaking Changes
None. This is a backward-compatible enhancement.

## Additional Notes
- Uses ssh2 library for SFTP implementation
- Maintains consistent interface between FTP and SFTP
- Improves overall reliability of file operations
- Ensures proper path handling across different operating systems

## Related Issues
Closes #3